### PR TITLE
Rename `nones` to `noneSignals` to more clearly explain why Unit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ val values: Observable<String> = Observable
     .filterSome()
 
 // Filter only None values emitted by RxJava2 Observable.
-val nones: Observable<Unit> = Observable
+val noneSignals: Observable<Unit> = Observable
     .just(Some("a"), None, Some("b"))
     .filterNone()
 ```


### PR DESCRIPTION
This should give explanation on why we emit `Unit` instead of `None` by `filterNone()`.