### PR TITLE
Fix Spek execution with IntelliJ plugin.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -19,6 +19,7 @@ ext.libraries = [
 
 
         junit                     : "junit:junit:$versions.junit",
+        junitPlatformLauncher     : "org.junit.platform:junit-platform-launcher:$versions.junitPlatform",
         spek                      : "org.jetbrains.spek:spek-api:$versions.spek",
         spekJunitPlatformEngine   : "org.jetbrains.spek:spek-junit-platform-engine:$versions.spek",
         assertJ                   : "org.assertj:assertj-core:$versions.assertJ",

--- a/koptional-rxjava2-extensions/build.gradle
+++ b/koptional-rxjava2-extensions/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     testCompile libraries.spek
     testCompile libraries.spekJunitPlatformEngine
     testCompile libraries.assertJ
+    testCompile libraries.junitPlatformLauncher
 }
 
 junitPlatform {

--- a/koptional/build.gradle
+++ b/koptional/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     testCompile libraries.spek
     testCompile libraries.spekJunitPlatformEngine
     testCompile libraries.assertJ
+    testCompile libraries.junitPlatformLauncher
 }
 
 junitPlatform {


### PR DESCRIPTION
Spek execution in IntelliJ using the Plugin is currently broken, because the plugin executes using junit-platform-launcher 1.0.0.M3 instead of the now expected M4 (see https://github.com/JetBrains/spek/issues/195).

Adding junit-platform-launcher 1.0.0.M4 to the test classpath is the suggested workaround.