### PR TITLE
Add None.toString

### DIFF
--- a/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
+++ b/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
@@ -9,6 +9,8 @@ sealed class Optional<out T : Any> {
 }
 
 data class Some<out T : Any>(val value: T) : Optional<T>()
-object None : Optional<Nothing>()
+object None : Optional<Nothing>() {
+    override fun toString() = "None"
+}
 
 fun <T : Any> T?.toOptional(): Optional<T> = if (this == null) None else Some(this)

--- a/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
+++ b/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
@@ -8,7 +8,10 @@ sealed class Optional<out T : Any> {
     }
 }
 
-data class Some<out T : Any>(val value: T) : Optional<T>()
+data class Some<out T : Any>(val value: T) : Optional<T>() {
+    override fun toString() = "Some($value)"
+}
+
 object None : Optional<Nothing>() {
     override fun toString() = "None"
 }

--- a/koptional/src/test/kotlin/com/gojuno/koptional/OptionalSpec.kt
+++ b/koptional/src/test/kotlin/com/gojuno/koptional/OptionalSpec.kt
@@ -49,4 +49,38 @@ class OptionalSpec : Spek({
             }
         }
     }
+
+    describe("toString") {
+
+        context("Some<Int>.toString") {
+
+            val result = Some(42).toString()
+
+            it("converts it to String") {
+                assertThat(result).isEqualTo("Some(42)")
+            }
+
+        }
+
+        context("Some<Object>.toString") {
+
+            val obj = Object()
+            val result = Some(obj).toString()
+
+            it("converts it to String") {
+                assertThat(result).isEqualTo("Some($obj)")
+            }
+
+        }
+
+        context("None.toString") {
+
+            val result = None.toString()
+
+            it("converts it to String") {
+                assertThat(result).isEqualTo("None")
+            }
+
+        }
+    }
 })


### PR DESCRIPTION
I often use this class for debugging, and calling something like `println("sessionId=$optional")` gives this:
```
sessionId=com.gojuno.koptional.None@7ce026d3
```
Why don't we override `toString`? :)
```
sessionId=None
```