### PR TITLE
Java interop version of toOptional()

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ val noneSignals: Observable<Unit> = Observable
     .map { none: Unit -> } // filterNone() maps None to Unit.
 ```
 
+### Interoperability with Java
+
+Use the static `Optional.toOptional()` method (declared as a companion object method) to wrap an 
+instance of `T` into `Optional<T>`.  
+
 ### Download
 
 Koptional is [available on jcenter](https://jcenter.bintray.com/com/gojuno/koptional).

--- a/koptional/build.gradle
+++ b/koptional/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     testCompile libraries.spekJunitPlatformEngine
     testCompile libraries.assertJ
     testCompile libraries.junitPlatformLauncher
+    testCompile libraries.junit
 }
 
 junitPlatform {

--- a/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
+++ b/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
@@ -24,7 +24,7 @@ sealed class Optional<out T : Any> {
          * prefer using the [toOptional][com.gojuno.koptional.toOptional] extension function.
          */
         @JvmStatic
-        fun <T : Any> toOptional(t: T?): Optional<T> = if (t == null) None else Some(t)
+        fun <T : Any> toOptional(value: T?): Optional<T> = if (value == null) None else Some(value)
     }
 }
 

--- a/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
+++ b/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
@@ -9,6 +9,20 @@ sealed class Optional<out T : Any> {
 
     companion object {
 
+        /**
+         * Wrap an instance of T (or null) into an [Optional]:
+         *
+         * ```
+         * String a = "str";
+         * String b = null;
+         *
+         * Optional<String> optionalA = Optional.toOptional(a); // Some("str")
+         * Optional<String> optionalB = Optional.toOptional(b); // None
+         * ```
+         *
+         * This is the preferred method of obtaining an instance of [Optional] in Java. In Kotlin,
+         * prefer using the [toOptional][com.gojuno.koptional.toOptional] extension function.
+         */
         @JvmStatic
         fun <T : Any> toOptional(t: T?): Optional<T> = t.toOptional()
     }
@@ -22,4 +36,19 @@ object None : Optional<Nothing>() {
     override fun toString() = "None"
 }
 
-fun <T : Any> T?.toOptional(): Optional<T> = if (this == null) None else Some(this)
+/**
+ * Wrap an instance of T (or null) into an [Optional]:
+ *
+ * ```
+ * val a: String? = "str"
+ * val b: String? = null
+ *
+ * val optionalA = a.toOptional() // Some("str")
+ * val optionalB = b.toOptional() // None
+ * ```
+ *
+ * This is the preferred method of obtaining an instance of [Optional] in Kotlin. In Java, prefer
+ * using the static [Optional.toOptional] method.
+ */
+@Suppress("NOTHING_TO_INLINE")
+inline fun <T : Any> T?.toOptional(): Optional<T> = if (this == null) None else Some(this)

--- a/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
+++ b/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
@@ -10,9 +10,9 @@ sealed class Optional<out T : Any> {
     companion object {
 
         /**
-         * Wrap an instance of T (or null) into an [Optional]:
+         * Wraps an instance of T (or null) into an [Optional]:
          *
-         * ```
+         * ```java
          * String a = "str";
          * String b = null;
          *
@@ -24,7 +24,7 @@ sealed class Optional<out T : Any> {
          * prefer using the [toOptional][com.gojuno.koptional.toOptional] extension function.
          */
         @JvmStatic
-        fun <T : Any> toOptional(t: T?): Optional<T> = t.toOptional()
+        fun <T : Any> toOptional(t: T?): Optional<T> = if (t == null) None else Some(t)
     }
 }
 
@@ -37,9 +37,9 @@ object None : Optional<Nothing>() {
 }
 
 /**
- * Wrap an instance of T (or null) into an [Optional]:
+ * Wraps an instance of T (or null) into an [Optional]:
  *
- * ```
+ * ```kotlin
  * val a: String? = "str"
  * val b: String? = null
  *
@@ -50,5 +50,4 @@ object None : Optional<Nothing>() {
  * This is the preferred method of obtaining an instance of [Optional] in Kotlin. In Java, prefer
  * using the static [Optional.toOptional] method.
  */
-@Suppress("NOTHING_TO_INLINE")
-inline fun <T : Any> T?.toOptional(): Optional<T> = if (this == null) None else Some(this)
+fun <T : Any> T?.toOptional(): Optional<T> = if (this == null) None else Some(this)

--- a/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
+++ b/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
@@ -6,6 +6,12 @@ sealed class Optional<out T : Any> {
         is Some -> value
         is None -> null
     }
+
+    companion object {
+
+        @JvmStatic
+        fun <T : Any> toOptional(t: T?): Optional<T> = t.toOptional()
+    }
 }
 
 data class Some<out T : Any>(val value: T) : Optional<T>() {

--- a/koptional/src/test/java/com/gojuno/koptional/OptionalSpecJava.java
+++ b/koptional/src/test/java/com/gojuno/koptional/OptionalSpecJava.java
@@ -21,8 +21,18 @@ public class OptionalSpecJava {
         assertThat(result).isEqualTo(new Some<>("string"));
     }
 
+    @Test public void nonNullToOptionalCompat() {
+        Optional<String> result = OptionalKt.toOptional("string");
+        assertThat(result).isEqualTo(new Some<>("string"));
+    }
+
     @Test public void nullToOptional() {
         Optional<Object> result = Optional.toOptional(null);
+        assertThat(result).isEqualTo(None.INSTANCE);
+    }
+
+    @Test public void nullToOptionalCompat() {
+        Optional<Object> result = OptionalKt.toOptional(null);
         assertThat(result).isEqualTo(None.INSTANCE);
     }
 }

--- a/koptional/src/test/java/com/gojuno/koptional/OptionalSpecJava.java
+++ b/koptional/src/test/java/com/gojuno/koptional/OptionalSpecJava.java
@@ -1,0 +1,28 @@
+package com.gojuno.koptional;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OptionalSpecJava {
+
+    @Test public void someToNullable() {
+        String result = new Some<>("string").toNullable();
+        assertThat(result).isEqualTo("string");
+    }
+
+    @Test public void noneToNullable() {
+        Object result = None.INSTANCE.toNullable();
+        assertThat(result).isNull();
+    }
+
+    @Test public void nonNullToOptional() {
+        Optional<String> result = Optional.toOptional("string");
+        assertThat(result).isEqualTo(new Some<>("string"));
+    }
+
+    @Test public void nullToOptional() {
+        Optional<Object> result = Optional.toOptional(null);
+        assertThat(result).isEqualTo(None.INSTANCE);
+    }
+}


### PR DESCRIPTION
We're sometimes calling `toOptional()` from Java and it would be more convenient to have `Optional.toOptional()` instead of `OptionalKt.toOptional()`.