### PR TITLE
very minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The goal of this implementation is to be convenient to use and fit Kotlin's null
   - `fun <T : Any> T?.toOptional(): Optional<T>`
   - `fun Optional.toNullable(): T?`
 * `Some` and `None` are declared as **top level types** — no need to write `Optional.Some` or `Optional.None`
-* No functions like `map()`, `getOrElse()`, `filter()`, etc — apply `toNullable()` and use Kotlin sdt functions like `let()`, `takeIf()` and so on.
+* No functions like `map()`, `getOrElse()`, `filter()`, etc — apply `toNullable()` and use Kotlin std functions like `let()`, `takeIf()` and so on.
 
 ### Usage
 


### PR DESCRIPTION
Fix a very minor typo (I think). sdt -> std.  Could also expand to standard or stdlib.