### PR TITLE
Switch to mavenCentral, cache Gradle on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,11 @@ deploy:
 
 notifications:
   email: false
+
+before_cache:
+  - rm -f  "$HOME"/.gradle/caches/modules-2/modules-2.lock
+
+cache:
+  directories:
+    - $HOME/.gradle/caches
+    - $HOME/.gradle/wrapper

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     apply plugin: 'com.github.ben-manes.versions'


### PR DESCRIPTION
Noticed that every CI build downloads all dependencies all over again, then remembered all the hassle with recent jcenter outages and inconsistencies and switched to mavenCentral gladly we have required deps there (although I believe Gradle plugins are still served by jcenter).