### PR TITLE
Single implementation for component1()

### DIFF
--- a/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
+++ b/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
@@ -10,7 +10,7 @@ sealed class Optional<out T : Any> {
     /**
      * Unwraps this optional into the value it holds or null if there is no value held.
      */
-    abstract operator fun component1(): T?
+    operator fun component1(): T? = toNullable()
 
     companion object {
 
@@ -40,8 +40,6 @@ data class Some<out T : Any>(val value: T) : Optional<T>() {
 
 object None : Optional<Nothing>() {
     override fun toString() = "None"
-
-    override fun component1(): Nothing? = null
 
     override fun toNullable(): Nothing? = null
 }


### PR DESCRIPTION
Creating PR for CI to see if covariance is kept for `component1()` in `Some`