### PR TITLE
Hide component1() destructuring from Java consumers

### DIFF
--- a/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
+++ b/koptional/src/main/kotlin/com/gojuno/koptional/Optional.kt
@@ -10,6 +10,7 @@ sealed class Optional<out T : Any> {
     /**
      * Unwraps this optional into the value it holds or null if there is no value held.
      */
+    @JvmSynthetic
     abstract operator fun component1(): T?
 
     companion object {


### PR DESCRIPTION
I propose simple change that i think would be beneficial from the perspective of java consumers, namely annotating `component1()` function with kotlin's `@JvmSynthetic`

As a consequence method will become invisible from Java. Long story short i think it's rather unneccesary to pollute java with a method that quite frankly doesn't say anything for them as the concept of kotlin's destructuring is simply not there. For getting actual values there is `toNullable` already so i don't see a point

Right now it looks like this:

![koptional-in-java](https://user-images.githubusercontent.com/2744747/43391846-106b5ac8-93f2-11e8-9701-5f9d6940eef8.png)
