### PR TITLE
Update Docker JDK image 8u121 → 8u252

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -38,7 +38,7 @@ docker run \
 --env BINTRAY_GPG_PASSPHRASE="$BINTRAY_GPG_PASSPHRASE" \
 --volume `"pwd"`:/opt/project \
 --rm \
-openjdk:8u121-jdk \
+openjdk:8u252-jdk \
 bash -c "$BUILD_COMMAND"
 
 popd


### PR DESCRIPTION
The previous one seems to be based on Debian Jessie, [packages of which were moved](https://unix.stackexchange.com/a/508728). This results in [build failures](https://travis-ci.org/github/gojuno/koptional/builds/701893031).

At this point we should probably move away to GitHub Actions but there is a good chance that a Bintray account was lost with Juno sudden shutdown. Good thing we have secrets stored as... Travis secrets and can do some clever hackery to extract them.

@artem-zinnatullin PTAL